### PR TITLE
Multi-Tenant support (fixing performance issue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add below dependency to your pom.
 
 To older versions use jitpack. Add the dependency in your pom as below.
 
-**NOTE**: Latest version published on Jetpack.io is 1.2.1
+**NOTE**: Last version published on Jetpack.io is 1.2.1
 
 ```xml
 <repositories>
@@ -41,7 +41,7 @@ To older versions use jitpack. Add the dependency in your pom as below.
 <dependency>
     <groupId>com.github.pablobastidasv</groupId>
     <artifactId>kc_security</artifactId>
-    <version>{verion}</version>
+    <version>{version}</version>
 </dependency>
 ```
 
@@ -134,9 +134,8 @@ NOTE: The property also can be set as `security.kc.multiTenant.enabled`.
 ### The `MultiTenantProducer` interface
 
 This interface requires the user to implement the method
-`adapterConfigFromRequest`, this method receives an `HttpServletRequest`
-parameter which can be used to determine the what URL the client reach
-and define what tenant information must be loaded.
+`adapterConfigFromRequest`, this method receives an `String`
+parameter which is the realm Key and thi will identify what tenant information must be loaded.
 
 Additionally, this method must return and `InputStream` created based on
 the information that the `keycloak.json` file contains.
@@ -147,9 +146,8 @@ Below an example about how to implement this interface.
 public class MultiTenantAdapterConfigProducer implements MultiTenantProducer {
 
     @Override
-    public InputStream adapterConfigFromRequest(HttpServletRequest httpServletRequest) {
-        String server = httpServletRequest.getServerName();
-        byte[] keycloakConfig = Optional.ofNullable(getKeycloakJsonString(server))
+    public InputStream adapterConfigFromRequest(String realmKey) {
+        byte[] keycloakConfig = Optional.ofNullable(getKeycloakJsonString(realmKey))
                 .map(String::getBytes)
                 .orElseGet(this::defaultConfig);
         return new ByteArrayInputStream(keycloakConfig);
@@ -157,7 +155,9 @@ public class MultiTenantAdapterConfigProducer implements MultiTenantProducer {
 }
 ```
 
-
+NOTE: By default the value of `realmKey` is the server name returned by `HttpServletRequest::getServerName`,
+if this value is not enough for you, you can always overwrite the method 
+`String obtainRealmNameKey(HttpServletRequest request)` and define the key string that fits better to you.
 
 ## Tested platforms
 

--- a/doc/sequence_diagram.puml
+++ b/doc/sequence_diagram.puml
@@ -1,0 +1,62 @@
+@startuml
+
+title Detailed - Sequence Diagram
+
+participant Server as s
+box "Keycloak library"
+    participant KeycloakAuthMechanism as kam
+    participant DeploymentProducer as dp
+    participant AdapterConfigProducer as acp
+end box
+box "Custom implementation"
+participant MultiTenantProducer as mtp
+end box
+
+s -> kam: validateRequest()
+activate kam
+kam -> dp: getDeployment()
+activate dp
+dp -> acp: obtainRealmNameKey(Request)
+activate acp
+alt when multi-tenant is enabled
+    acp -> mtp: obtainRealmNameKey(HttpServletRequest)
+    activate mtp
+    acp <- mtp
+    deactivate mtp
+else
+    acp -> acp:
+    note right: return default value "default"
+    activate acp
+    deactivate acp
+end alt
+dp <- acp
+deactivate acp
+alt deployment does not exist in map (cache)
+    dp -> acp: produceAdapterConfig(realmKey:String)
+    activate acp
+    alt when multi-tenant is enabled
+        acp -> mtp: adapterConfigFromRequest(realmKey:String)
+        activate mtp
+        acp <- mtp
+        deactivate mtp
+    else
+        acp -> acp
+        note right: Build based on configuration.
+        activate acp
+        deactivate acp
+    end alt
+    dp <- acp
+    deactivate acp
+    dp -> dp: Store deployment in map (cache)
+    activate dp
+    deactivate dp
+end alt
+kam <- dp: deployment from cache
+deactivate dp
+kam -> kam: validate user
+activate kam
+deactivate kam
+s <- kam
+deactivate kam
+
+@enduml

--- a/examples/service/pom.xml
+++ b/examples/service/pom.xml
@@ -23,8 +23,8 @@
 
         <dependency>
             <groupId>io.github.pablobastidasv</groupId>
-            <artifactId>kc</artifactId>
-            <version>1.4</version>
+            <artifactId>kc_security</artifactId>
+            <version>2.0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>fish.payara.maven.plugins</groupId>
                 <artifactId>payara-micro-maven-plugin</artifactId>
-                <version>1.0.2</version>
+                <version>1.0.3</version>
                 <configuration>
                     <deployWar>true</deployWar>
                 </configuration>

--- a/src/main/java/co/pablob/security/kc/control/DeploymentProducer.java
+++ b/src/main/java/co/pablob/security/kc/control/DeploymentProducer.java
@@ -3,12 +3,15 @@ package co.pablob.security.kc.control;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.adapters.KeycloakDeploymentBuilder;
+import org.keycloak.representations.adapters.config.AdapterConfig;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
 public class DeploymentProducer {
@@ -20,17 +23,19 @@ public class DeploymentProducer {
     @ConfigProperty(name = "security.kc.multiTenant.enabled", defaultValue = "false")
     boolean multiTenant;
 
-    private KeycloakDeployment deployment;
+    private final Map<String, KeycloakDeployment> deployments = new ConcurrentHashMap<>();
 
-    public KeycloakDeployment getDeployment(HttpServletRequest request) throws IOException, URISyntaxException {
-        if(multiTenant){
-            return KeycloakDeploymentBuilder.build(adapterConfigProducer.produceAdapterConfig(request));
+    public KeycloakDeployment getDeployment(HttpServletRequest request) {
+        String realmName = adapterConfigProducer.obtainRealmNameKey(request);
+
+        return deployments.computeIfAbsent(realmName, key -> KeycloakDeploymentBuilder.build(getAdapterConfig(key)));
+    }
+
+    private AdapterConfig getAdapterConfig(String realmName)  {
+        try {
+            return adapterConfigProducer.produceAdapterConfig(realmName);
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException(e);
         }
-
-        if(deployment == null){
-            deployment = KeycloakDeploymentBuilder.build(adapterConfigProducer.produceAdapterConfig(request));
-        }
-
-        return deployment;
     }
 }

--- a/src/main/java/co/pablob/security/kc/control/KeycloakAuthMechanism.java
+++ b/src/main/java/co/pablob/security/kc/control/KeycloakAuthMechanism.java
@@ -16,8 +16,6 @@ import javax.security.enterprise.authentication.mechanism.http.HttpMessageContex
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
@@ -39,27 +37,23 @@ public class KeycloakAuthMechanism implements HttpAuthenticationMechanism {
             HttpServletResponse response,
             HttpMessageContext httpMessageContext) {
 
-        try {
-            final String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
-            if (authorizationHeader != null && authorizationHeader.startsWith(BEARER)) {
-                KeycloakDeployment deployment = deploymentProducer.getDeployment(request);
-                BearerTokenRequestAuthenticator authenticator = new BearerTokenRequestAuthenticator(deployment);
-                HttpFacade facade = new ServletHttpFacade(request, response);
+        final String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+        if (authorizationHeader != null && authorizationHeader.startsWith(BEARER)) {
+            KeycloakDeployment deployment = deploymentProducer.getDeployment(request);
+            BearerTokenRequestAuthenticator authenticator = new BearerTokenRequestAuthenticator(deployment);
+            HttpFacade facade = new ServletHttpFacade(request, response);
 
-                final AuthOutcome authResult = authenticator.authenticate(facade);
+            final AuthOutcome authResult = authenticator.authenticate(facade);
 
-                if (AuthOutcome.AUTHENTICATED == authResult) {
-                    return authenticationStatus(deployment.getResourceName(), authenticator,
-                            deployment, httpMessageContext);
-                }
-
-                return httpMessageContext.responseUnauthorized();
+            if (AuthOutcome.AUTHENTICATED == authResult) {
+                return authenticationStatus(deployment.getResourceName(), authenticator,
+                        deployment, httpMessageContext);
             }
 
-            return httpMessageContext.notifyContainerAboutLogin(new JwtPrincipal(), new HashSet<>());
-        } catch (IOException | URISyntaxException e) {
             return httpMessageContext.responseUnauthorized();
         }
+
+        return httpMessageContext.notifyContainerAboutLogin(new JwtPrincipal(), new HashSet<>());
     }
 
     private AuthenticationStatus authenticationStatus(

--- a/src/main/java/co/pablob/security/kc/control/MultiTenantProducer.java
+++ b/src/main/java/co/pablob/security/kc/control/MultiTenantProducer.java
@@ -5,5 +5,35 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public interface MultiTenantProducer {
-    InputStream adapterConfigFromRequest(HttpServletRequest request) throws IOException;
+
+    /**
+     *  Based on the request will create an {@code InputStream} with the keycloak realm configuration information.
+     *
+     * @param request The incoming request
+     * @return An input stream with the Realm information, normally a json file provided by Keycloak
+     * @throws IOException In case the {@code InputStream} generation present some IO error.
+     * @deprecated due to performance issues, now this method will be not used, this will make a passthrough
+     *      to {@link MultiTenantProducer::obtainRealmNameKey} which receives a {@code String} passing value
+     *      from {@link HttpServletRequest::getServerName}.
+     */
+    @Deprecated
+    default InputStream adapterConfigFromRequest(HttpServletRequest request) throws IOException {
+        return adapterConfigFromRequest(request.getServerName());
+    };
+
+
+    /**
+     *  Based on the a String to identify the key of the realm, create an {@code InputStream} with the
+     *  keycloak realm configuration information.
+     *
+     * @param realmKeyName a {@code String} which represents the information of the realm to build.
+     * @return An input stream with the Realm information, normally a json file provided by Keycloak
+     * @throws IOException In case the {@code InputStream} generation present some IO error.
+     */
+    InputStream adapterConfigFromRequest(String realmKeyName) throws IOException;
+
+
+    default String obtainRealmNameKey(HttpServletRequest request){
+        return request.getServerName();
+    }
 }

--- a/src/test/java/co/pablob/security/kc/control/AdapterConfigProducerTest.java
+++ b/src/test/java/co/pablob/security/kc/control/AdapterConfigProducerTest.java
@@ -4,8 +4,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.representations.adapters.config.AdapterConfig;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -20,11 +18,10 @@ public class AdapterConfigProducerTest {
     private static final String EXPECTED_CLIENT_ID = "services";
     private static final String EXPECTED_REALM = "dev";
 
-    private HttpServletRequest request;
+    private String realmNameKey = "default";
 
     @Before
     public void setUp() throws Exception {
-        request = mock(HttpServletRequest.class);
     }
 
     @Test
@@ -38,7 +35,7 @@ public class AdapterConfigProducerTest {
         adapterConfigProducer.realm = EXPECTED_REALM;
 
         // when
-        final AdapterConfig adapterConfig = adapterConfigProducer.produceAdapterConfig(request);
+        final AdapterConfig adapterConfig = adapterConfigProducer.produceAdapterConfig(realmNameKey);
 
         // then
         assertEquals(EXPECTED_SERVICE_URL, adapterConfig.getAuthServerUrl());
@@ -59,7 +56,7 @@ public class AdapterConfigProducerTest {
         adapterConfigProducer.realm = UNCONFIGURED_VALUE;
 
         // when
-        final AdapterConfig adapterConfig = adapterConfigProducer.produceAdapterConfig(request);
+        final AdapterConfig adapterConfig = adapterConfigProducer.produceAdapterConfig(realmNameKey);
 
         // then
         assertEquals(EXPECTED_SERVICE_URL, adapterConfig.getAuthServerUrl());
@@ -78,7 +75,7 @@ public class AdapterConfigProducerTest {
         adapterConfigProducer.realm = UNCONFIGURED_VALUE;
 
         // when
-        adapterConfigProducer.produceAdapterConfig(request);
+        adapterConfigProducer.produceAdapterConfig(realmNameKey);
         fail("Exception should be throws");
     }
 
@@ -93,7 +90,7 @@ public class AdapterConfigProducerTest {
         adapterConfigProducer.realm = UNCONFIGURED_VALUE;
 
         // when
-        final AdapterConfig adapterConfig = adapterConfigProducer.produceAdapterConfig(request);
+        final AdapterConfig adapterConfig = adapterConfigProducer.produceAdapterConfig(realmNameKey);
 
         // then
         assertEquals(EXPECTED_SERVICE_URL, adapterConfig.getAuthServerUrl());


### PR DESCRIPTION
  - A performance issue was identified, this was causing the `Deployment`
  object was recreated per request when multitenant mode was enabled.
  Now the system use a cache based on `keyName` to store the instance
  of the `Deployment` making it stateful between all requests.